### PR TITLE
Helm Hub provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Currently supports fetching releases from:
 - [Docker Hub](https://hub.docker.com)
 - [PyPI](https://pypi.org)
 - [JetBrains](https://www.jetbrains.com)
+- [Helm Hub](https://hub.helm.sh)
 
 Currently supports notifications to:
 
@@ -58,6 +59,10 @@ releases:
   jetbrains:
     - name: go
       alias: GoLand
+
+  helmhub:
+    - repo: bitnami
+      chart: airflow
 ```
 
 The root `releases` holds mappings, keyed by the provider name, and the value being a list of project configurations. The available providers and their related configuration is listed below.
@@ -103,6 +108,16 @@ This provider accepts some optional configuration parameters, either from enviro
 The `jetbrains` provider looks for new releases for JetBrains applications. The configuration items need to have a `name` property, which is the application ID as JetBrains knows it. It could also include an `alias` property to display in the notifications instead of the ID.
 
 This provider accepts some optional configuration parameters, either from environment variables, or a key-value file at `/var/secrets/jetbrains` in `KEY=VALUE` format on each line.
+
+| Key | Description | Default |
+| --- | ----------- | ------- |
+| `HTTP_TIMEOUT` | The HTTP timeout for API calls | `30s` |
+
+### Helm Hub
+
+The `helmhub` provider looks for new Helm chart versions. The configuration items need to have a `repo` property and a `chart`.
+
+This provider accepts some optional configuration parameters, either from environment variables, or a key-value file at `/var/secrets/helmhub` in `KEY=VALUE` format on each line.
 
 | Key | Description | Default |
 | --- | ----------- | ------- |

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ Currently supports fetching releases from:
 
 - [GitHub](https://github.com)
 - [Docker Hub](https://hub.docker.com)
-- [PyPI](TODO)
-- [JetBrains](TODO)
+- [PyPI](https://pypi.org)
+- [JetBrains](https://www.jetbrains.com)
 
 Currently supports notifications to:
 
-- [Slack](TODO)
+- [Slack](https://slack.com)
 
 The application periodically checks the target projects using their provider, and sends out a notificiation with some details about new releases when it finds them. Previously seen releases are kept in a [SQLite](TODO) database.
 
@@ -29,7 +29,7 @@ $ docker run -d --name release-watcher 				\
 	rycus86/release-watcher
 ```
 
-Alternatively, build with Go (tested on version 1.10), then execute:
+Alternatively, build with Go (tested on version 1.10, 1.14), then execute:
 
 ```shell
 $ export DATABASE_PATH=$PWD/releases.db

--- a/main_test.go
+++ b/main_test.go
@@ -87,6 +87,10 @@ func TestWaitForChanges(t *testing.T) {
 		"https://data.services.jetbrains.com/products?code=GO",
 		"./testdata/jetbrains_releases.json",
 	)
+	registerResponderFromFile(
+		"https://hub.helm.sh/api/chartsvc/v1/charts/argo/argo/versions",
+		"./testdata/helmhub_releases.json",
+	)
 
 	configuration := model.Configuration{
 		Releases: map[string][]model.GenericProject{
@@ -101,6 +105,9 @@ func TestWaitForChanges(t *testing.T) {
 			},
 			"jetbrains": {
 				&providers.JetBrainsProject{Name: "go", Alias: "GoLand"},
+			},
+			"helmhub": {
+				&providers.HelmHubProject{Repo: "argo", Chart: "argo"},
 			},
 		},
 	}
@@ -226,6 +233,33 @@ func TestWaitForChanges(t *testing.T) {
 		t.Error("Unexpected calls to webhookSender.Send:", notifier.callSend)
 	}
 	if !strings.Contains(webhookSender.callSend, "GoLand:2018.1 (181.4203.567)") {
+		t.Error("Unexpected calls to webhookSender.Send:", notifier.callSend)
+	}
+
+	if !strings.Contains(store.callExists, "argo/argo:0.7.2") {
+		t.Error("Unexpected calls to store.Exists:", store.callExists)
+	}
+	if !strings.Contains(store.callExists, "argo/argo:0.6.1") {
+		t.Error("Unexpected calls to store.Exists:", store.callExists)
+	}
+	if !strings.Contains(store.callMark, "argo/argo:0.7.2") {
+		t.Error("Unexpected calls to store.Mark:", store.callMark)
+	}
+	if !strings.Contains(store.callMark, "argo/argo:0.6.1") {
+		t.Error("Unexpected calls to store.Mark:", store.callMark)
+	}
+
+	if strings.Contains(notifier.callSend, "argo/argo:0.6.1") {
+		t.Error("Unexpected calls to notifier.SendNotification:", notifier.callSend)
+	}
+	if !strings.Contains(notifier.callSend, "argo/argo:0.7.2") {
+		t.Error("Unexpected calls to notifier.SendNotification:", notifier.callSend)
+	}
+
+	if !strings.Contains(webhookSender.callSend, "argo/argo:0.6.1") {
+		t.Error("Unexpected calls to webhookSender.Send:", notifier.callSend)
+	}
+	if !strings.Contains(webhookSender.callSend, "argo/argo:0.7.2") {
 		t.Error("Unexpected calls to webhookSender.Send:", notifier.callSend)
 	}
 }

--- a/providers/helmhub.go
+++ b/providers/helmhub.go
@@ -1,0 +1,106 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/rycus86/release-watcher/env"
+	"github.com/rycus86/release-watcher/model"
+	"github.com/rycus86/release-watcher/transport"
+)
+
+type HelmHubProvider struct {
+	client *http.Client
+}
+
+type helmHubResponse struct {
+	Data []struct {
+		Attributes struct {
+			Version string `json:"version"`
+			Created string `json:"created"`
+		} `json:"attributes"`
+	} `json:"data"`
+}
+
+type HelmHubProject struct {
+	model.BaseProject `mapstructure:",squash"`
+
+	Repo  string
+	Chart string
+}
+
+func (p HelmHubProject) String() string {
+	if p.Repo != "" {
+		return fmt.Sprintf("%s/%s", p.Repo, p.Chart)
+	} else {
+		return p.Chart
+	}
+}
+
+func (provider *HelmHubProvider) Initialize() {
+	provider.client = &http.Client{
+		Timeout:   env.GetTimeout("HTTP_TIMEOUT", "/var/secrets/dockerhub"),
+		Transport: &transport.HttpTransportWithUserAgent{},
+	}
+
+	RegisterProvider(provider)
+}
+
+func (provider *HelmHubProvider) GetName() string {
+	return "HelmHub"
+}
+
+func (provider *HelmHubProvider) Parse(input interface{}) model.GenericProject {
+	var project HelmHubProject
+
+	err := mapstructure.Decode(input, &project)
+	if err != nil {
+		return nil
+	}
+
+	return &project
+}
+
+func (provider *HelmHubProvider) FetchReleases(p model.GenericProject) ([]model.Release, error) {
+	var releases []model.Release
+
+	project := p.(*HelmHubProject)
+
+	apiURL := fmt.Sprintf(
+		"https://hub.helm.sh/api/chartsvc/v1/charts/%s/%s/versions",
+		project.Repo, project.Chart)
+
+	response, err := provider.client.Get(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+
+	var apiResponse = helmHubResponse{}
+	err = json.NewDecoder(response.Body).Decode(&apiResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, release := range apiResponse.Data {
+		url := fmt.Sprintf("https://hub.helm.sh/charts/%s/%s/%s", project.Repo, project.Chart, release.Attributes.Version)
+		created, err := time.Parse(time.RFC3339Nano, release.Attributes.Created)
+		if err != nil {
+			created = time.Now()
+		}
+
+		releases = append(releases, model.Release{
+			Name: release.Attributes.Version,
+			URL:  url,
+			Date: created,
+
+			Provider: provider,
+			Project:  project,
+		})
+	}
+
+	return releases, nil
+}

--- a/providers/helmhub_test.go
+++ b/providers/helmhub_test.go
@@ -1,0 +1,52 @@
+package providers
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"gopkg.in/jarcoal/httpmock.v1"
+)
+
+func TestFetchHelmHubReleases(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	testdata, err := ioutil.ReadFile("../testdata/helmhub_releases.json")
+	if err != nil {
+		t.Errorf("Failed to load test data: %s", err)
+	}
+
+	httpmock.RegisterResponder(
+		"GET", "https://hub.helm.sh/api/chartsvc/v1/charts/argo/argo/versions",
+		httpmock.NewStringResponder(200, string(testdata)),
+	)
+
+	provider := HelmHubProvider{
+		client: &http.Client{},
+	}
+
+	releases, err := provider.FetchReleases(&HelmHubProject{Repo: "argo", Chart: "argo"})
+	if err != nil {
+		t.Error("Failed:", err)
+	}
+
+	if len(releases) != 22 {
+		t.Error("Unexpected number of releases:", len(releases))
+	}
+
+	if releases[0].Name != "0.7.2" {
+		t.Error("Unexpected release:", releases[0].Name)
+	}
+	if releases[3].Name != "0.6.8" {
+		t.Error("Unexpected release:", releases[1].Name)
+	}
+
+	if releases[0].Date.Year() != 2020 || releases[0].Date.Month() != 3 || releases[0].Date.Day() != 19 {
+		t.Errorf("Unexpected date: %s", releases[0].Date.String())
+	}
+
+	if releases[0].URL != "https://hub.helm.sh/charts/argo/argo/0.7.2/" {
+		t.Error("Unexpected URL:", releases[0].URL)
+	}
+}

--- a/providers/registration.go
+++ b/providers/registration.go
@@ -31,4 +31,5 @@ func InitializeProviders() {
 	(&DockerHubProvider{}).Initialize()
 	(&PyPIProvider{}).Initialize()
 	(&JetBrainsProvider{}).Initialize()
+	(&HelmHubProvider{}).Initialize()
 }

--- a/testdata/helmhub_releases.json
+++ b/testdata/helmhub_releases.json
@@ -1,0 +1,818 @@
+{
+  "data": [
+    {
+      "id": "argo/argo-0.7.2",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.7.2",
+        "app_version": "v2.6.1",
+        "created": "2020-03-19T18:56:27.428Z",
+        "digest": "5cbbca72cb3917426068619f42a59a54417a7fb4431634a1b6ef39b804fa0bfd",
+        "urls": ["argo-0.7.2.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.7.2/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.7.2/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.7.2" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.7.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.7.1",
+        "app_version": "v2.6.1",
+        "created": "2020-03-19T18:56:27.427Z",
+        "digest": "464353c341d43ba6c4a256423704752ad6eaf1c25342152dc2b27be749e7df7a",
+        "urls": ["argo-0.7.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.7.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.7.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.7.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.7.0",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.7.0",
+        "app_version": "v2.6.1",
+        "created": "2020-03-19T18:56:27.425Z",
+        "digest": "d78077d7531b7844a5e3d008654349559795567ad0951bf755f110dcc2db46f9",
+        "urls": ["argo-0.7.0.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.7.0/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.7.0/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.7.0" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.8",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.8",
+        "app_version": "v2.4.3",
+        "created": "2020-03-19T18:56:27.424Z",
+        "digest": "794313e143b2890206b7edbf9df0412a3cb8268bc854827d6327487642dc3287",
+        "urls": ["argo-0.6.8.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.8/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.8/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.8" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.7",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.7",
+        "app_version": "v2.4.3",
+        "created": "2020-03-19T18:56:27.422Z",
+        "digest": "991e429d6eb0c31757dc78939da93116ccb101ab1e2f031eb7f4abf50242ee1c",
+        "urls": ["argo-0.6.7.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.7/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.7/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.7" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.6",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.6",
+        "app_version": "v2.4.3",
+        "created": "2020-03-19T18:56:27.42Z",
+        "digest": "7a68be4c7660bc7f211e347c077e09323503118982d8d89e720a4c0bf93e4d4f",
+        "urls": ["argo-0.6.6.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.6/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.6/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.6" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.5",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.5",
+        "app_version": "v2.4.3",
+        "created": "2020-03-19T18:56:27.419Z",
+        "digest": "eb82d8f0ec94a9ade65be65043c01e861020953c47bc0536c712041171d391a5",
+        "urls": ["argo-0.6.5.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.5/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.5/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.5" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.4",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.4",
+        "app_version": "v2.4.3",
+        "created": "2020-03-19T18:56:27.418Z",
+        "digest": "6cb99e8e5ce0aa100ba4ec27f801b6879ad4157bdb1bf0a0f773c9828be4f45a",
+        "urls": ["argo-0.6.4.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.4/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.4/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.4" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.3",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.3",
+        "app_version": "v2.4.2",
+        "created": "2020-03-19T18:56:27.417Z",
+        "digest": "1a272543f2b2b69bf05f064f694552c66784bca716fb3dc5a8302b9a176b275d",
+        "urls": ["argo-0.6.3.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.3/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.3/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.3" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.2",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.2",
+        "app_version": "v2.4.2",
+        "created": "2020-03-19T18:56:27.416Z",
+        "digest": "768b18b6bb86e0c63d9e17563cee4ac0ab65b3ac8744182e987eca92b14fd898",
+        "urls": ["argo-0.6.2.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.2/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.2/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.2" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.6.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.6.1",
+        "app_version": "v2.4.2",
+        "created": "2020-03-19T18:56:27.415Z",
+        "digest": "2608a9e77b269d53a2c1038b41810938497d81ce1d85f3ff9c6274b82d6e304f",
+        "urls": ["argo-0.6.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.6.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.6.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.6.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.5.4",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.5.4",
+        "app_version": "v2.3.0",
+        "created": "2020-03-19T18:56:27.414Z",
+        "digest": "05cbb2419812b8da0f0f3149d343cab705b596282a3fa92664603a3611bc1fb7",
+        "urls": ["argo-0.5.4.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.5.4/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.5.4/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.5.4" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.5.3",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.5.3",
+        "app_version": "v2.3.0",
+        "created": "2020-03-19T18:56:27.412Z",
+        "digest": "747411b921c351795fc53928e0e464e697aa5bbf35d02b76ed90527af3c7678b",
+        "urls": ["argo-0.5.3.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.5.3/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.5.3/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.5.3" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.5.2",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.5.2",
+        "app_version": "v2.3.0",
+        "created": "2020-03-19T18:56:27.411Z",
+        "digest": "1d20e5c32c0f295b6df5abbb733b48b6ab34bead8c16dd63e4c4f6ccb155eafc",
+        "urls": ["argo-0.5.2.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.5.2/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.5.2/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.5.2" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.5.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.5.1",
+        "app_version": "v2.3.0",
+        "created": "2020-03-19T18:56:27.41Z",
+        "digest": "f6703b5ee03915d9e1184ddffb7a1bc88d3a025e68a61375d676ec3e2a67192e",
+        "urls": ["argo-0.5.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.5.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.5.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.5.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.5.0",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.5.0",
+        "app_version": "v2.3.0",
+        "created": "2020-03-19T18:56:27.407Z",
+        "digest": "675656b6269249a3028bd5d4d0d2d04dfbe6698a9ff11cda969f1c4a25c38d60",
+        "urls": ["argo-0.5.0.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.5.0/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.5.0/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.5.0" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.4.0",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.4.0",
+        "app_version": "v2.2.1",
+        "created": "2020-03-19T18:56:27.406Z",
+        "digest": "82040c2cf671d4dceda8c27b04623f94d4883069cbe612686a64a1eecedf7eda",
+        "urls": ["argo-0.4.0.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.4.0/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.4.0/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.4.0" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.3.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.3.1",
+        "app_version": "",
+        "created": "2020-03-19T18:56:27.404Z",
+        "digest": "91351dfac1ce2210e0fa8e532cb585f8af450cc7bb70314adb051241363f7db6",
+        "urls": ["argo-0.3.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.3.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.3.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.3.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.3.0",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.3.0",
+        "app_version": "",
+        "created": "2020-03-19T18:56:27.403Z",
+        "digest": "f88682348f4f2b470f1df840929a6a9ce584d8a499e0c0085a71371de9582275",
+        "urls": ["argo-0.3.0.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.3.0/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.3.0/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.3.0" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.2.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.2.1",
+        "app_version": "",
+        "created": "2020-03-19T18:56:27.402Z",
+        "digest": "eea1d669e5495c611aa6d51965fd8b7d71eac15382ab71ebbde73ca54af5a3fe",
+        "urls": ["argo-0.2.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.2.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.2.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.2.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.1.1",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.1.1",
+        "app_version": "",
+        "created": "2020-03-19T18:56:27.4Z",
+        "digest": "a0255641d6ae6bc533f5594003bf39f911ec35fc1198e6627ca84c93f3fd941f",
+        "urls": ["argo-0.1.1.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.1.1/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.1.1/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.1.1" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    },
+    {
+      "id": "argo/argo-0.1.0",
+      "type": "chartVersion",
+      "attributes": {
+        "version": "0.1.0",
+        "app_version": "",
+        "created": "2020-03-19T18:56:27.399Z",
+        "digest": "f7393a1c9e0a25f19692857a4a9d20ed0199243712cd9d3af2f44995724c1909",
+        "urls": ["argo-0.1.0.tgz"],
+        "readme": "/v1/assets/argo/argo/versions/0.1.0/README.md",
+        "values": "/v1/assets/argo/argo/versions/0.1.0/values.yaml"
+      },
+      "links": { "self": "/v1/charts/argo/argo/versions/0.1.0" },
+      "relationships": {
+        "chart": {
+          "data": {
+            "name": "argo",
+            "repo": {
+              "name": "argo",
+              "url": "https://argoproj.github.io/argo-helm"
+            },
+            "description": "A Helm chart for Argo Workflows",
+            "home": "https://github.com/argoproj/argo-helm",
+            "keywords": [],
+            "maintainers": [
+              { "name": "alexec" },
+              { "name": "alexmt" },
+              { "name": "jessesuen" },
+              { "name": "benjaminws" }
+            ],
+            "sources": [],
+            "icon": "/v1/assets/argo/argo/logo"
+          },
+          "links": { "self": "/v1/charts/argo/argo" }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Commits:
1. Updated the README: missing links, tested Go version
2. Added Helm Hub provider for watching new Helm Chart releases on https://hub.helm.sh/
<img width="309" alt="image" src="https://user-images.githubusercontent.com/15990318/77624442-1c354800-6f42-11ea-9b93-a9dfc9204056.png">

Closes #4 