### PR TITLE
Artifacthub timeout, README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Currently supports fetching releases from:
 - [Docker Hub](https://hub.docker.com)
 - [PyPI](https://pypi.org)
 - [JetBrains](https://www.jetbrains.com)
-- [Helm Hub](https://hub.helm.sh)
 - [Artifact Hub](https://artifacthub.io)
+- [Helm Hub](https://hub.helm.sh) (Deprecated)
 
 Currently supports notifications to:
 
@@ -66,9 +66,8 @@ releases:
       chart: airflow
 
   artifacthub:
-    - owner: bitnami
+    - repo: bitnami
       chart: postgresql
-
 ```
 
 The root `releases` holds mappings, keyed by the provider name, and the value being a list of project configurations. The available providers and their related configuration is listed below.

--- a/providers/artifacthub.go
+++ b/providers/artifacthub.go
@@ -40,7 +40,7 @@ func (p ArtifactHubProject) String() string {
 
 func (provider *ArtifactHubProvider) Initialize() {
 	provider.client = &http.Client{
-		Timeout:   env.GetTimeout("HTTP_TIMEOUT", "/var/secrets/dockerhub"),
+		Timeout:   env.GetTimeout("HTTP_TIMEOUT", "/var/secrets/artifacthub"),
 		Transport: &transport.HttpTransportWithUserAgent{},
 	}
 


### PR DESCRIPTION
Looks like I forgot to push my latest changes in #14, sorry about that.
* This fixes the broken config example `owner` -> `repo`
* Fixes the Timeout parameter which currenly is set to `dockerhub` in Artifact Hub
